### PR TITLE
Manual Boot is Unnecessary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,7 @@ you can simply leave them un-configured.
 ### CipherSweet Trait
 
 If this is not tenable due to existing object inheritance requirements, you may also
-simply use the `CipherSweet` trait and then add `static::bootCipherSweet()` to your
-`boot()` method, like so.
+simply use the `CipherSweet` trait, like so.
 
 ```php
 <?php
@@ -65,18 +64,6 @@ use ParagonIE\EloquentCipherSweet\CipherSweet;
 class Blah extends Model
 {
     use CipherSweet;
-
-    /**
-     * The "booting" method of the model.
-     *
-     * @return void
-     */
-    protected static function boot()
-    {
-        parent::boot();
-        /* ...other custom code here... */
-        static::bootCipherSweet();
-    }    
 }
 ```
 

--- a/src/EncryptedFieldModel.php
+++ b/src/EncryptedFieldModel.php
@@ -20,6 +20,5 @@ class EncryptedFieldModel extends Model
     protected static function boot()
     {
         parent::boot();
-        static::bootCipherSweet();
     }
 }


### PR DESCRIPTION
Manually booting the trait is unnecessary, per \Illuminate\Database\Eloquent\Model::bootTraits. `bootCipherSweet` complies with the naming convention defined in that method and so will automatically be run.