### PR TITLE
Add Integration For Custom Key Providers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,3 +109,12 @@ If you're not familiar with the `EncryptedMultiRows` API, please refer to the
 relevant section of the [CipherSweet documentation](https://github.com/paragonie/ciphersweet/tree/master/docs#encryptedmultirows).
 
 ## Storing and Searching on Encrypted Data
+
+
+## Creating a Custom Key Provider
+
+If you would like to use your own custom key provider implementation, e.g. to integrate with AWS KMS, specify 'custom'
+as your option for 'provider' in `config/ciphersweet.php`, uncomment the 'via' line and replace the class there with the
+name of your own key provider factory class. It should implement the `__invoke` method and return a class that
+implements `\ParagonIE\CipherSweet\Contract\KeyProviderInterface`. `__invoke` will be passed an instance of
+`\ParagonIE\CipherSweet\Contract\BackendInterface` as its sole argument.

--- a/src/CipherSweetServiceProvider.php
+++ b/src/CipherSweetServiceProvider.php
@@ -64,6 +64,8 @@ class CipherSweetServiceProvider extends ServiceProvider
     protected function buildKeyProvider(BackendInterface $backend): KeyProviderInterface
     {
         switch (config('ciphersweet.provider')) {
+            case 'custom':
+                return $this->buildCustomKeyProvider($backend);
             case 'file':
                 return new FileProvider($backend, config('ciphersweet.file.path'));
             case 'string':
@@ -72,5 +74,18 @@ class CipherSweetServiceProvider extends ServiceProvider
             default:
                 return new RandomProvider($backend);
         }
+    }
+
+    /**
+     * Override me to provide a custom KeyProviderInterface instance.
+     *
+     * @param BackendInterface $backend
+     * @return KeyProviderInterface
+     */
+    protected function buildCustomKeyProvider(BackendInterface $backend): KeyProviderInterface
+    {
+        $factory = app(config('ciphersweet.custom.via'));
+
+        return $factory($backend);
     }
 }

--- a/src/CipherSweetServiceProvider.php
+++ b/src/CipherSweetServiceProvider.php
@@ -77,8 +77,6 @@ class CipherSweetServiceProvider extends ServiceProvider
     }
 
     /**
-     * Override me to provide a custom KeyProviderInterface instance.
-     *
      * @param BackendInterface $backend
      * @return KeyProviderInterface
      */

--- a/src/config/ciphersweet.php
+++ b/src/config/ciphersweet.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default Backend
+    | Cryptographic Backend
     |--------------------------------------------------------------------------
     |
     | This controls which cryptographic backend will be used by CipherSweet.
@@ -19,8 +19,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default Key Provider
+    | Key Provider
     |--------------------------------------------------------------------------
+    |
+    | Select which key provider your application will use. The default option
+    | is to read a string literal out of .env, but it's also possible to
+    | provide the key in a file, use a custom key provider, or use random keys
+    | for testing.
+    |
+    | "string" is selected by default to read a key directly from your .env
+    | file. Use `artisan ciphersweet:generate:key` to securely generate that
+    | key.
+    |
+    | Supported: "custom", "file", "random", "string"
+    |
     */
 
     'provider' => env('CIPHERSWEET_PROVIDER', 'string'),
@@ -30,8 +42,10 @@ return [
     | Key Providers
     |--------------------------------------------------------------------------
     |
-    | Configure the
-    | Supported: "custom", "file", "random", "string"
+    | Set provider-specific options here. "string" will read the key directly
+    | from your .env file. "file" will read the contents of the specified file
+    | to use as your key. "custom" points to a factory class that returns a
+    | provider from its `__invoke` method. Please see the docs for more details.
     |
     */
 

--- a/src/config/ciphersweet.php
+++ b/src/config/ciphersweet.php
@@ -31,11 +31,14 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure the
-    | Supported: "file", "random", "string"
+    | Supported: "custom", "file", "random", "string"
     |
     */
 
     'providers' => [
+        'custom' => [
+            //'via' => \App\CipherSweetKey\CreateKeyProvider::class,
+        ],
         'file' => [
             'path' => env('CIPHERSWEET_FILE_PATH'),
         ],


### PR DESCRIPTION
Addresses the concern raised in https://github.com/paragonie/eloquent-ciphersweet/pull/3#issuecomment-471722107. This adds support for creating custom key providers. The implementation follows the example set by Laravel's [custom Logger configuration](https://laravel.com/docs/5.8/logging#creating-channels-via-factories) to try to stay as idiomatic to the framework as possible for ease of use.