### PR TITLE
Add migration to create centralized blind index table.

### DIFF
--- a/src/CipherSweetServiceProvider.php
+++ b/src/CipherSweetServiceProvider.php
@@ -27,6 +27,8 @@ class CipherSweetServiceProvider extends ServiceProvider
             ]);
         }
 
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
+
         $this->publishes([
             __DIR__ . '/config/ciphersweet.php' => config_path('ciphersweet.php'),
         ]);

--- a/src/database/migrations/2019_03_16_182552_create_blind_indexes_table.php
+++ b/src/database/migrations/2019_03_16_182552_create_blind_indexes_table.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ParagonIE\EloquentCipherSweet\database\migrations;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+final class CreateBlindIndexesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('blind_indexes', function (Blueprint $table) {
+            $table->string('type');
+            $table->string('value');
+            $table->unsignedInteger('foreign_id');
+
+            $table->index(['type', 'value']);
+            $table->unique(['type', 'foreign_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('blind_indexes');
+    }
+}


### PR DESCRIPTION
Intentionally providing no model for the table, since it shouldn't really have direct access.